### PR TITLE
Add support for transparent overlay

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,6 +29,7 @@
   "start_url": ".",
   "id": "/",
   "display": "standalone",
+  "display_override": ["window-controls-overlay"],
   "theme_color": "#1976d2",
   "background_color": "#ffffff"
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,14 +2,16 @@ import { Container, AppBar, Toolbar, Typography } from "@mui/material";
 
 const Nav = (props: { elementRight: JSX.Element }) => {
   return (
-    <AppBar position="static">
-      <Container maxWidth="xl">
+    <AppBar position="sticky">
+      <Container maxWidth="xl" className="navbar">
         <Toolbar variant="dense">
           <Typography
             variant="h6"
             color="inherit"
             component="div"
-            sx={{ flexGrow: 1 }}
+            sx={{
+              flexGrow: 1,
+            }}
           >
             Calendar
           </Typography>

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,16 @@
   box-sizing: border-box;
   font-family: "Roboto", Arial, Helvetica, sans-serif;
 }
+
+.navbar {
+  margin-left: env(titlebar-area-x, auto) !important;
+  margin-top: env(titlebar-area-y, auto) !important;
+  max-width: env(titlebar-area-width, 1536px) !important;
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+
+.navbar button {
+  app-region: no-drag;
+  -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
Closes #18
- popup now darkens navbar
- no double navbar for installed PWAs anymore

https://user-images.githubusercontent.com/18506129/194937948-e61e9d26-7dea-484c-b6f7-cd4613eac235.mp4

Only tested using Chrome on Windows. *Should* work on Mac (i.e. with nav button on the left) as well, but not tested.