### PR TITLE
Cache if accept header includes text/calendar

### DIFF
--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -8,7 +8,11 @@ const Calendar = (props: { url: string; start: Date }) => {
   const [events, setEvents] = useState<Event[] | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(true);
   if (loading) {
-    fetch(props.url)
+    fetch(props.url, {
+      headers: {
+        accept: "text/calendar",
+      },
+    })
       .then((r) => r.text())
       .then((text) => {
         const jCalData = iCal.parse(text);

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -31,10 +31,11 @@ registerRoute(
   })
 );
 
-// Cache calendar files (.ics) but always serve the latest version if possible
+// Cache calendars but always serve the latest version if possible
 registerRoute(
-  ({ url }) =>
-    url.origin === self.location.origin && url.pathname.endsWith(".ics"),
+  ({ url, request }) =>
+    url.origin === self.location.origin &&
+    request.headers.get("accept")?.includes("text/calendar"),
   new NetworkFirst({
     cacheName: "calendars",
     plugins: [new ExpirationPlugin({ maxEntries: 50 })],


### PR DESCRIPTION
This approach caches all requests including "text/calendar" in the "accept" header, which is now set by default when requesting the calendar. Ok so, @JM-Lemmi oder ist ne andere approach besser?